### PR TITLE
Fix `gedcom_view.py` for very large GEDCOM file.

### DIFF
--- a/gedcom_view.py
+++ b/gedcom_view.py
@@ -1,60 +1,64 @@
 #!/usr/bin/env python
-
-"""
-A simple viewer for gedcom files.
-This automatically indents lines
-"""
+"""Print colorized, indented GEDCOM lines."""
 
 import sys
 
-
 indentation_size = 3
 
-fg_reset  = '\033[0;m'
 
-def yellow(s):
-    return '\033[1;33m' + s + fg_reset
-def gray(s):
-    return '\033[1;30m' + s + fg_reset
-def red(s):
-    return '\033[1;31m' + s + fg_reset
-def green(s):
-    return '\033[1;32m' + s + fg_reset
+def colorize(s, color):
+    """
+    Colorize GEDCOM Line/Tag elements for sys.stdout.
+
+    Arguments:
+        s {str} -- Tag element.
+        color {str} -- ASCII color Escape code.
+
+    Returns:
+        [str] -- Tag element enveloped by ASCII color escape codes.
+
+    """
+    fg_reset = '\033[0;m'
+    colors = {
+        'yellow': '\033[1;33m',
+        'gray': '\033[1;30m',
+        'red': '\033[1;31m',
+        'green': '\033[1;32m'
+        }
+    return colors[color] + s + fg_reset
 
 
 if len(sys.argv) == 1:
     gedcom = sys.stdin
 else:
-    gedcom = open(sys.argv[1], "r")
+    with open(sys.argv[1], 'r', buffering=1) as gedcom_file:
+        gedcom = gedcom_file.readlines()
 
-buffer = gedcom.read().replace('\r\n', '\n').replace('\r', '\n')
-
-line_num=1
-for line in buffer.splitlines():
+for line_number, line in enumerate(gedcom):
     comps = line.split()
 
     level = comps[0]
 
-    xref  = ""
-    tag   = 1
+    xref = ""
+    tag = 1
 
     if comps[tag].startswith("@"):
-        xref = yellow(comps[1]) + " "
-        tag   = 2
+        xref = comps[1] + " "
+        tag = 2
 
     value = tag + 1
 
     if value < len(comps) and comps[value].startswith("@"):
-        comps[value] = yellow(comps[value])
+        comps[value] = colorize(comps[value], 'yellow')
 
-    sys.stdout.write("%s %s%s %s%s %s\n" % (
-        gray("%5d" % line_num),
-        int(level) * indentation_size * ' ',
-        green(level),
-        xref,
-        red(comps[tag]),
-        " ".join(comps[value:])))
+    indentation = (int(level) * indentation_size) * ' '
+    formatting = "{}{}{} {}{} {}"
+    format_data = (
+        colorize("{0:>5}".format(line_number + 1), 'gray'),
+        indentation + ' ',
+        colorize(level, 'green'),
+        colorize(xref, 'yellow'),
+        colorize(comps[tag], 'red'),
+        " ".join(comps[value:]))
 
-    line_num += 1
-
-
+    sys.stdout.write(formatting.format(*format_data) + '\n')


### PR DESCRIPTION
Fix `gedcom_view.py` for very large GEDCOM files as input.

This should correct the python issue with handling `read()` for files in the multi-gigabyte range in `open()` in `gedcom_view.py`.