### PR TITLE
Django 2 transition

### DIFF
--- a/backend/geneaprove/models/__init__.py
+++ b/backend/geneaprove/models/__init__.py
@@ -54,7 +54,7 @@ class Project (GeneaProveModel):
                                          through="Researcher_Project")
     name = models.CharField(max_length=100)
     description = models.TextField(null=True)
-    scheme = models.ForeignKey(Surety_Scheme, default=1)
+    scheme = models.ForeignKey(Surety_Scheme, default=1, on_delete=models.CASCADE)
     client_data = models.TextField(
         null=True,
         help_text="The client for which the project is undertaken. In general"
@@ -76,8 +76,8 @@ class Researcher_Project (GeneaProveModel):
     given researcher might be working simulatenously on several projects.
     """
 
-    researcher = models.ForeignKey(Researcher, null=False)
-    project = models.ForeignKey(Project)
+    researcher = models.ForeignKey(Researcher, null=False, on_delete=models.CASCADE)
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
     role = models.TextField(
         null=True,
         help_text="Role that the researcher plays for that project")
@@ -98,7 +98,7 @@ class Research_Objective (GeneaProveModel):
     An objective is accomplished in terms of activities.
     """
 
-    project = models.ForeignKey(Project)
+    project = models.ForeignKey(Project, on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
     description = models.TextField(null=True)
     sequence_number = models.IntegerField(default=1)
@@ -120,7 +120,7 @@ class Activity (GeneaProveModel):
     """
 
     objectives = models.ManyToManyField(Research_Objective)
-    researcher = models.ForeignKey(Researcher, null=True)
+    researcher = models.ForeignKey(Researcher, null=True, on_delete=models.CASCADE)
     scheduled_date = models.DateField(null=True)
     completed_date = models.DateField(null=True)
     is_admin = models.BooleanField(
@@ -148,9 +148,9 @@ class Repository_Source (GeneaProveModel):
     all the possible repositories where they are found
     """
 
-    repository = models.ForeignKey(Repository)
-    source = models.ForeignKey(Source)
-    activity = models.ForeignKey(Activity, null=True)
+    repository = models.ForeignKey(Repository, on_delete=models.CASCADE)
+    source = models.ForeignKey(Source, on_delete=models.CASCADE)
+    activity = models.ForeignKey(Activity, null=True, on_delete=models.CASCADE)
     call_number = models.CharField(max_length=200, null=True)
     description = models.TextField(null=True)
 
@@ -168,13 +168,14 @@ class Search (GeneaProveModel):
     necessarily, if for instance this is an unexpected opportunity
     """
 
-    activity = models.ForeignKey(Activity, null=True)
+    activity = models.ForeignKey(Activity, null=True, on_delete=models.CASCADE)
     source = models.ForeignKey(
         Source, null=True,
         help_text="The source in which the search was conducted. It could"
         " be null if this was a general search in a repository for"
-        " instance")
-    repository = models.ForeignKey(Repository)
+        " instance",
+        on_delete=models.CASCADE)
+    repository = models.ForeignKey(Repository, on_delete=models.CASCADE)
     searched_for = models.TextField(null=True)
 
     class Meta:

--- a/backend/geneaprove/models/asserts.py
+++ b/backend/geneaprove/models/asserts.py
@@ -41,14 +41,15 @@ class Assertion(GeneaProveModel):
     personas (Persona,Persona).
     """
 
-    surety = models.ForeignKey(Surety_Scheme_Part)
-    researcher = models.ForeignKey(Researcher, null=False)
+    surety = models.ForeignKey(Surety_Scheme_Part, on_delete=models.CASCADE)
+    researcher = models.ForeignKey(Researcher, null=False, on_delete=models.CASCADE)
     source = models.ForeignKey(
         Source, null=True,
         help_text="An assertion comes from no more than one source. It can"
         " also come from one or more other assertions through the"
         " assertion_assertion table, in which case source_id is"
-        " null")
+        " null",
+        on_delete=models.CASCADE)
     rationale = models.TextField(
         null=True,
         help_text="Explains why the assertion (deduction, comments,...)")
@@ -108,9 +109,9 @@ class P2P(Assertion):
     """Persona-to-Persona assertions, to represent the Persona.sameAs
        relationship.
     """
-    person1 = models.ForeignKey(Persona, related_name="p2p_from")
-    person2 = models.ForeignKey(Persona, related_name="p2p_to")
-    type = models.ForeignKey(P2P_Type)
+    person1 = models.ForeignKey(Persona, related_name="p2p_from", on_delete=models.CASCADE)
+    person2 = models.ForeignKey(Persona, related_name="p2p_to", on_delete=models.CASCADE)
+    type = models.ForeignKey(P2P_Type, on_delete=models.CASCADE)
 
     class Meta:
         db_table = "p2p"
@@ -135,8 +136,8 @@ class P2P(Assertion):
 class P2C(Assertion):
     """Persona-to-Characteristic assertions"""
 
-    person = models.ForeignKey(Persona, related_name="p2c")
-    characteristic = models.ForeignKey(Characteristic, related_name="persons")
+    person = models.ForeignKey(Persona, related_name="p2c", on_delete=models.CASCADE)
+    characteristic = models.ForeignKey(Characteristic, related_name="persons", on_delete=models.CASCADE)
 
     class Meta:
         """Meta data for the model"""
@@ -177,9 +178,9 @@ class P2C(Assertion):
 class P2E(Assertion):
     """Persona-to-Event assertions"""
 
-    person = models.ForeignKey(Persona, related_name="events")
-    event = models.ForeignKey(Event, related_name="actors")
-    role = models.ForeignKey(Event_Type_Role, null=True)
+    person = models.ForeignKey(Persona, related_name="events", on_delete=models.CASCADE)
+    event = models.ForeignKey(Event, related_name="actors", on_delete=models.CASCADE)
+    role = models.ForeignKey(Event_Type_Role, null=True, on_delete=models.CASCADE)
 
     def __str__(self):
         role = f" (as {self.role_id if self.role_id else ''})"
@@ -208,9 +209,9 @@ class P2E(Assertion):
 
 class P2G(Assertion):
     """Persona-to-Group assertions"""
-    person = models.ForeignKey(Persona, related_name="groups")
-    group = models.ForeignKey(Group, related_name="personas")
-    role = models.ForeignKey(Group_Type_Role, null=True)
+    person = models.ForeignKey(Persona, related_name="groups", on_delete=models.CASCADE)
+    group = models.ForeignKey(Group, related_name="personas", on_delete=models.CASCADE)
+    role = models.ForeignKey(Group_Type_Role, null=True, on_delete=models.CASCADE)
 
     class Meta:
         """Meta data for the model"""
@@ -236,12 +237,12 @@ class P2G(Assertion):
 #       Such assertions are not part of the GENTECH super-statement, but
 #       are used in particular to store event notes imported from GEDCOM
 #    """
-#   event      = models.ForeignKey (Event, related_name="characteristics")
-#   characteristic = models.ForeignKey (Characteristic, related_name="events")
+#   event      = models.ForeignKey (Event, related_name="characteristics", on_delete=models.CASCADE)
+#   characteristic = models.ForeignKey (Characteristic, related_name="events", on_delete=models.CASCADE)
 
 #class Assertion_Assertion (GeneaProveModel):
-#    original = models.ForeignKey(Assertion, related_name="leads_to")
-#    deduction = models.ForeignKey(Assertion, related_name="deducted_from")
+#    original = models.ForeignKey(Assertion, related_name="leads_to", on_delete=models.CASCADE)
+#    deduction = models.ForeignKey(Assertion, related_name="deducted_from", on_delete=models.CASCADE)
 #    sequence_number = models.IntegerField(default=1)
 #
 #    class Meta:

--- a/backend/geneaprove/models/characteristic.py
+++ b/backend/geneaprove/models/characteristic.py
@@ -29,7 +29,7 @@ class Characteristic(GeneaProveModel):
         help_text="Name of the characteristic. This could be guessed from"
         " its parts only if there is one of the latter, so we store"
         " it here""")
-    place = models.ForeignKey(Place, null=True)
+    place = models.ForeignKey(Place, null=True, on_delete=models.CASCADE)
     date = models.CharField(
         max_length=100, null=True,
         help_text="Date as read in the original source")
@@ -65,8 +65,8 @@ class Characteristic_Part(GeneaProveModel):
     characteristic, and therefore various parts might be needed.
     """
 
-    characteristic = models.ForeignKey(Characteristic, related_name="parts")
-    type = models.ForeignKey(Characteristic_Part_Type)
+    characteristic = models.ForeignKey(Characteristic, related_name="parts", on_delete=models.CASCADE)
+    type = models.ForeignKey(Characteristic_Part_Type, on_delete=models.CASCADE)
     name = models.TextField()
     sequence_number = models.IntegerField(default=1)
 

--- a/backend/geneaprove/models/event.py
+++ b/backend/geneaprove/models/event.py
@@ -27,7 +27,8 @@ class Event_Type_Role(GeneaProveModel):
     type = models.ForeignKey(
         Event_Type, null=True, blank=True,
         help_text="The event type for which the role is defined. If unset,"
-        " this applies to all events")
+        " this applies to all events",
+        on_delete=models.CASCADE)
     name = models.CharField(max_length=50)
 
     class Meta:
@@ -55,8 +56,8 @@ class Event(GeneaProveModel):
     assertion.
     """
 
-    type = models.ForeignKey(Event_Type)
-    place = models.ForeignKey(Place, null=True)
+    type = models.ForeignKey(Event_Type, on_delete=models.CASCADE)
+    place = models.ForeignKey(Place, null=True, on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
     date = models.CharField(
         max_length=100, null=True,

--- a/backend/geneaprove/models/group.py
+++ b/backend/geneaprove/models/group.py
@@ -21,7 +21,7 @@ class Group_Type_Role(GeneaProveModel):
     The role a person can have in a group
     """
 
-    type = models.ForeignKey(Group_Type, related_name="roles")
+    type = models.ForeignKey(Group_Type, related_name="roles", on_delete=models.CASCADE)
     name = models.CharField(max_length=200)
     sequence_number = models.IntegerField(default=1)
 
@@ -36,8 +36,8 @@ class Group(GeneaProveModel):
     The groups as found in our various sources
     """
 
-    type = models.ForeignKey(Group_Type)
-    place = models.ForeignKey(Place, null=True)
+    type = models.ForeignKey(Group_Type, on_delete=models.CASCADE)
+    place = models.ForeignKey(Place, null=True, on_delete=models.CASCADE)
     name = models.CharField(max_length=200)
     date = models.CharField(
         max_length=100, null=True,

--- a/backend/geneaprove/models/place.py
+++ b/backend/geneaprove/models/place.py
@@ -21,7 +21,8 @@ class Place(GeneaProveModel):
 
     parent_place = models.ForeignKey(
         'self', null=True,
-        help_text="The parent place, that contains this one")
+        help_text="The parent place, that contains this one",
+        on_delete=models.CASCADE)
     name = models.CharField(
         max_length=100, help_text="Short description of the place")
 
@@ -85,8 +86,8 @@ class Place_Part(GeneaProveModel):
     # ??? Should the existence date be a place_part as well, or a field in
     # a place part, so that the same place with different names results in
     # a single id
-    place = models.ForeignKey(Place, related_name="parts")
-    type = models.ForeignKey(Place_Part_Type)
+    place = models.ForeignKey(Place, related_name="parts", on_delete=models.CASCADE)
+    type = models.ForeignKey(Place_Part_Type, on_delete=models.CASCADE)
     name = models.CharField(max_length=200)
     sequence_number = models.PositiveSmallIntegerField(
         "Sequence number", default=1)

--- a/backend/geneaprove/models/repository.py
+++ b/backend/geneaprove/models/repository.py
@@ -28,9 +28,9 @@ class Repository(GeneaProveModel):
     A repository might also be a person you interviewed one or more times
     """
 
-    place = models.ForeignKey(Place, null=True)
+    place = models.ForeignKey(Place, null=True, on_delete=models.CASCADE)
     name = models.CharField(max_length=200)
-    type = models.ForeignKey(Repository_Type, null=True)
+    type = models.ForeignKey(Repository_Type, null=True, on_delete=models.CASCADE)
     info = models.TextField(null=True)
     addr = models.TextField(null=True)
 

--- a/backend/geneaprove/models/representation.py
+++ b/backend/geneaprove/models/representation.py
@@ -10,7 +10,7 @@ class Representation(GeneaProveModel):
     """
 
     mime_type = models.CharField(max_length=40)
-    source = models.ForeignKey(Source, related_name="representations")
+    source = models.ForeignKey(Source, related_name="representations", on_delete=models.CASCADE)
     file = models.TextField(null=True)
     comments = models.TextField(null=True)
 

--- a/backend/geneaprove/models/researcher.py
+++ b/backend/geneaprove/models/researcher.py
@@ -9,7 +9,7 @@ class Researcher(GeneaProveModel):
     """
 
     name = models.CharField(max_length=100)
-    place = models.ForeignKey(Place, null=True)
+    place = models.ForeignKey(Place, null=True, on_delete=models.CASCADE)
     comment = models.TextField(
         null=True,
         help_text="Contact information for this researcher, like email"

--- a/backend/geneaprove/models/source.py
+++ b/backend/geneaprove/models/source.py
@@ -21,17 +21,20 @@ class Source(GeneaProveModel):
         related_name="sources",
         through="Repository_Source")
     higher_source = models.ForeignKey(
-        "self", related_name="lower_sources", null=True)
+        "self", related_name="lower_sources", null=True,
+        on_delete=models.CASCADE)
     subject_place = models.ForeignKey(
         Place, null=True, related_name="sources",
-        help_text="Where the event described in the source takes place")
+        help_text="Where the event described in the source takes place",
+        on_delete=models.CASCADE)
     jurisdiction_place = models.ForeignKey(
         Place, null=True,
         related_name="jurisdiction_for",
         help_text="Example: a record in North Carolina describes a person"
         " and their activities in Georgia. Georgia is the subject"
-        " place, whereas NC is the jurisdiction place")
-    researcher = models.ForeignKey(Researcher, null=False)
+        " place, whereas NC is the jurisdiction place",
+        on_delete=models.CASCADE)
+    researcher = models.ForeignKey(Researcher, null=False, on_delete=models.CASCADE)
     subject_date = models.CharField(
         max_length=100, null=True,
         help_text="the date of the subject. Note that the dates might be" +
@@ -185,8 +188,8 @@ class Citation_Part(GeneaProveModel):
     Stores the citation for a source, such as author, title,...
     """
 
-    source = models.ForeignKey(Source, related_name='parts')
-    type = models.ForeignKey(Citation_Part_Type)
+    source = models.ForeignKey(Source, related_name='parts', on_delete=models.CASCADE)
+    type = models.ForeignKey(Citation_Part_Type, on_delete=models.CASCADE)
     value = models.TextField()
 
     class Meta:

--- a/backend/geneaprove/models/surety.py
+++ b/backend/geneaprove/models/surety.py
@@ -28,7 +28,7 @@ class Surety_Scheme_Part(GeneaProveModel):
     An element of a Surety_Scheme
     """
 
-    scheme = models.ForeignKey(Surety_Scheme, related_name="parts")
+    scheme = models.ForeignKey(Surety_Scheme, related_name="parts", on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
     description = models.TextField(null=True, blank=True)
     sequence_number = models.IntegerField(default=1)

--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ else
    fi
 fi
 
-pip install django==1.10.6 pillow grandalf django-prepared-query appdirs
+pip install django>=2.1 pillow grandalf django-prepared-query appdirs
 
 if [ "$DEVELOPER" != "no" ]; then
    # Some useful tools for developers. 


### PR DESCRIPTION
Added `on_delete` to `ForeignKey` definitions in `models`. Using `PROTECT` at the moment, though it might be worth considering which `on_delete` is best in each instance.

Removed version dependency from `pip ... django ...` in `setup.sh`.