### PR TITLE
Replaced deprecated time.clock() with time.perf_counter().

### DIFF
--- a/backend/backend/middleware/simple_exception.py
+++ b/backend/backend/middleware/simple_exception.py
@@ -13,14 +13,14 @@ class AJAXSimpleExceptionResponse(object):
     def __call__(self, request):
 
         # Code to be executed before the view
-        start = time.clock ()
+        start = time.perf_counter()
         self.has_exception = False
 
         response = self.get_response(request)
 
         # Code to be executed after the view
         if settings.DEBUG and len(connection.queries):
-           end = time.clock()
+           end = time.perf_counter()
            total = 0.0
 
            for r, q in enumerate(connection.queries):


### PR DESCRIPTION
time.clock() has been removed as of Python 3.8, which causes the server to fail.

See:

```
API and Feature Removals

The following features and APIs have been removed from Python 3.8:
...
    The function time.clock() has been removed, after having been deprecated since Python 3.3: use time.perf_counter() or time.process_time() instead, depending on your requirements, to have well-defined behavior. (Contributed by Matthias Bussonnier in bpo-36895.)
```
-- https://docs.python.org/3/whatsnew/3.8.html#time